### PR TITLE
🔒 chore(go.mod): update github.com/hecigo/goutils to v0.0.0-202305190…

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/go-redis/cache/v8 v8.4.4
 	github.com/go-redis/redis/v8 v8.11.5
 	github.com/goccy/go-json v0.10.2
-	github.com/hecigo/goutils v0.0.0-20230517091116-6afc65cc76f9
+	github.com/hecigo/goutils v0.0.0-20230519033910-bfef629263e1
 	go.elastic.co/apm/module/apmgoredisv8/v2 v2.4.1
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c
 )
@@ -39,5 +39,3 @@ require (
 	golang.org/x/tools v0.9.1 // indirect
 	howett.net/plist v1.0.0 // indirect
 )
-
-replace github.com/hecigo/goutils => ../goutils

--- a/go.sum
+++ b/go.sum
@@ -53,6 +53,8 @@ github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
+github.com/hecigo/goutils v0.0.0-20230519033910-bfef629263e1 h1:UwjE+E4RhbQ2vdoZ0CNqqlXIrMBwIyJaylEVoenrjgQ=
+github.com/hecigo/goutils v0.0.0-20230519033910-bfef629263e1/go.mod h1:qk7PzEy+zLCVM+iHVDqX4nZwzPmACBpBwHcha029vsE=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/jcchavezs/porto v0.1.0/go.mod h1:fESH0gzDHiutHRdX2hv27ojnOVFco37hg1W6E9EZF4A=
 github.com/jcchavezs/porto v0.4.0 h1:Zj7RligrxmDdKGo6fBO2xYAHxEgrVBfs1YAja20WbV4=


### PR DESCRIPTION
…33910-bfef629263e1

The go.mod file has been updated to use the latest version of the github.com/hecigo/goutils package. This update is necessary to ensure that the application is using the latest version of the package and to take advantage of any bug fixes or new features that may have been added.